### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/tneciv/zhihudaily/Api/ZhihuApi.java
+++ b/app/src/main/java/com/tneciv/zhihudaily/Api/ZhihuApi.java
@@ -3,7 +3,7 @@ package com.tneciv.zhihudaily.api;
 /**
  * Created by Tneciv on 1-16-0016.
  */
-public class ZhihuApi {
+public final class ZhihuApi {
 
     public static final String NEWS_CONTENT = "http://dudu.zhihu.com/api/4/news/";
     public static final String NEWS_HOT = "http://dudu.zhihu.com/api/6/news/hot";
@@ -12,6 +12,10 @@ public class ZhihuApi {
     public static final String THEME_NEWS_LIST = "http://dudu.zhihu.com/api/6/section/";
     public static final String NEWS_LATEST = "http://dudu.zhihu.com/api/4/news/latest";
     public static final String NEWS_DETAIL = "http://dudu.zhihu.com/story/";
+
+    private ZhihuApi() throws InstantiationException{
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static String getNewsContentUrl(int id) {
         return NEWS_CONTENT + id;

--- a/app/src/main/java/com/tneciv/zhihudaily/Costants/OperatorTag.java
+++ b/app/src/main/java/com/tneciv/zhihudaily/Costants/OperatorTag.java
@@ -3,6 +3,11 @@ package com.tneciv.zhihudaily.costants;
 /**
  * Created by Tneciv on 1-16-0016.
  */
-public class OperatorTag {
+public final class OperatorTag {
     public static final String REFRESH = "refresh";
+
+    private OperatorTag() throws InstantiationException{
+        throw new InstantiationException("This class is not for instantiation");
+    }
+    
 }

--- a/app/src/main/java/com/tneciv/zhihudaily/home/model/HomeEventEntity.java
+++ b/app/src/main/java/com/tneciv/zhihudaily/home/model/HomeEventEntity.java
@@ -5,7 +5,12 @@ import java.util.List;
 /**
  * Created by Tneciv on 1-17-0017.
  */
-public class HomeEventEntity {
+public final class HomeEventEntity {
+
+    private HomeEventEntity() throws InstantiationException{
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static class HotEntityList {
         private List<HotEntity> hotEntities;
 

--- a/app/src/main/java/com/tneciv/zhihudaily/theme/model/ThemeResultEntity.java
+++ b/app/src/main/java/com/tneciv/zhihudaily/theme/model/ThemeResultEntity.java
@@ -5,7 +5,12 @@ import java.util.List;
 /**
  * Created by Tneciv on 2-12-0012.
  */
-public class ThemeResultEntity {
+public final class ThemeResultEntity {
+
+    private ThemeResultEntity() throws InstantiationException{
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static class ThemeList {
         private List<ThemeEntity> entities;
 

--- a/app/src/main/java/com/tneciv/zhihudaily/utils/OkhttpUtils.java
+++ b/app/src/main/java/com/tneciv/zhihudaily/utils/OkhttpUtils.java
@@ -6,8 +6,12 @@ import okhttp3.OkHttpClient;
 /**
  * Created by Tneciv on 1-15-0015.
  */
-public class OkhttpUtils {
+public final class OkhttpUtils {
     static volatile OkHttpClient defaultInstance;
+
+    private OkhttpUtils() throws InstantiationException{
+        throw new InstantiationException("This class is not for instantiation");
+    }
 
     public static OkHttpClient getInstance() {
         if (defaultInstance == null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
